### PR TITLE
besttracks/core.py: workaround pd.Timedelta lack of method astype

### DIFF
--- a/besttracks/core.py
+++ b/besttracks/core.py
@@ -133,7 +133,7 @@ class Particle(object):
             Duration of this particle in unit of day
         """
         duration = np.ptp(self.records['TIME'])
-        return duration.astype('timedelta64[h]').astype(int) / 24.0
+        return pd.to_timedelta([duration]).astype('timedelta64[h]')[0] / 24.0
     
     
     def resample(self, *args, **kwargs):


### PR DESCRIPTION
method provides fix for the  issue of pandas.Timedelta not having the 'astype' method.
An invocation of the duration triggered an error. 