### PR TITLE
Update deprecated pandas date parser usage

### DIFF
--- a/besttracks/io.py
+++ b/besttracks/io.py
@@ -236,17 +236,17 @@ def parse_GDPDrifters(
     # Read data from files
     if chunksize is None:
         iters = [pd.read_fwf(f, header=None, colspecs=cols, names=colN,
-                             parse_dates=['TIME'], dtype=dtyp,
-                             date_parser=__parse_datetime)
+                             dtype=dtyp)
                  for f in paths]
         chunks = iters  # No need for iteration when not using chunks
     else:
         iters = [pd.read_fwf(f, header=None, colspecs=cols, names=colN,
-                             parse_dates=['TIME'], iterator=True,
-                             chunksize=chunksize, dtype=dtyp,
-                             date_parser=__parse_datetime)
+                             iterator=True, chunksize=chunksize, dtype=dtyp)
                  for f in paths]
         chunks = [chunk for it in iters for chunk in it]  # Flatten chunks
+
+    for chunk in chunks:
+        chunk['TIME'] = chunk['TIME'].map(__parse_datetime)
 
     # Apply record condition if provided
     if rec_cond is not None:


### PR DESCRIPTION
This updates GDP drifter fixed-width parsing to avoid the deprecated pandas `date_parser` argument in `read_fwf()`.

The old `date_parser` keyword was deprecated in pandas 2.0.0 in favor of `date_format`. The GDP drifter time field uses fractional-day codes such as `.250`, `.500`, and `.750`, so this keeps the existing custom parser and applies it explicitly after reading the fixed-width data. No behavior change is intended.

Tested with:
- `python3 -m py_compile besttracks/io.py`
- Minimal `parse_GDPDrifters(..., rawframe=True)` check for both regular and chunked reads, confirming `.250` and `.500` still parse to 06:00 and 12:00.